### PR TITLE
Update get_platform() to identify newer macOS

### DIFF
--- a/aip/parser.py
+++ b/aip/parser.py
@@ -54,7 +54,7 @@ def get_platform():
             _os = 'i686-pc-linux-gnu'
         elif _platform.find('aarch64') >= 0: 
             _os = 'aarch64-linux-gnu'
-    elif _platform.find('Darwin') >= 0:
+    elif _platform.find('Darwin') >= 0 or _platform.find('macOS') >= 0:
             _os = 'x86_64-apple-darwin'
     
     return _os


### PR DESCRIPTION
My MacBook Air 2015 with macOS Catalina returns ‘macOS-10.15.7-x86_64-i386-64bit’ for platform.platform()

I tested it with ardupy-lis3dhtr.

Now the Build command works and downloads the correct tools.

for more information see: https://forum.seeedstudio.com/t/config-aip-ardupycore-seeeduino-tools-missing/255055