### PR TITLE
Fix _download_http_url and unpack_url() issues.

### DIFF
--- a/aip/build.py
+++ b/aip/build.py
@@ -32,7 +32,6 @@ from pip._internal.models.link import Link
 import shutil
 
 from pip._internal.operations.prepare import (
-    _download_http_url,
     unpack_url,
 )
 import os
@@ -70,7 +69,6 @@ class buildCommand(RequirementCommand):
             cmdoptions.index_group,
             self.parser,
         )
-
         self.serial = SerialUtils()
         self.parser.insert_option_group(0, index_opts)
         self.srcfile = []
@@ -323,7 +321,7 @@ const mp_obj_module_t mp_module_arduino = {
                 unpack_url(
                     Link(archiveFile['url']),
                     ardupycoredir,
-                    downloader=downloader,
+                    downloader,
                     download_dir=None,
                 )
             except Exception as e:
@@ -347,7 +345,7 @@ const mp_obj_module_t mp_module_arduino = {
                     unpack_url(
                         Link(tool['url']),
                         tooldir,
-                        downloader=downloader,
+                        downloader,
                         download_dir=None,
                     )
                 except Exception as e:

--- a/aip/flash.py
+++ b/aip/flash.py
@@ -35,7 +35,6 @@ from aip.logger import log
 from aip.utils import dealGenericOptions
 
 from pip._internal.operations.prepare import (
-    _download_http_url,
     unpack_url,
 )
 import os

--- a/aip/install.py
+++ b/aip/install.py
@@ -34,7 +34,6 @@ from urllib.parse import urlparse
 import requests
 
 from pip._internal.operations.prepare import (
-    _download_http_url,
     unpack_url,
 )
 
@@ -162,7 +161,7 @@ class installCommand(RequirementCommand):
                     unpack_url(
                         Link(package_url),
                         package_location,
-                        downloader=downloader,
+                        downloader,
                         download_dir=None,
                     )
             except Exception as error:
@@ -188,7 +187,7 @@ class installCommand(RequirementCommand):
                             unpack_url(
                                 Link(dependency_url),
                                 dependency_location,
-                                downloader=downloader,
+                                downloader,
                                 download_dir=None,
                             )
                         except Exception as error:

--- a/aip/shell.py
+++ b/aip/shell.py
@@ -55,7 +55,6 @@ from pip._internal.network.download import Downloader
 from pip._internal.models.link import Link
 
 from pip._internal.operations.prepare import (
-    _download_http_url,
     unpack_url,
 )
 

--- a/aip/uninstall.py
+++ b/aip/uninstall.py
@@ -33,7 +33,6 @@ from pip._internal.models.link import Link
 from urllib.parse import urlparse
 
 from pip._internal.operations.prepare import (
-    _download_http_url,
     unpack_url,
 )
 


### PR DESCRIPTION
This fixes Issue #8.

I was not able to reproduce the problem I encountered with not creating the ~/.config/aip/modules directory, and the code appears correct (though you can use the exists_ok option to os.makedirs rather than check for existing).

```bash
aip board
```
still fails if my XIAO-based Altoid MIDI Box was already plugged in. The --desc option does not help (and it does not seem to use the "desc" datum, but rather "name". I'll submit this as a separate issue.
