### PR TITLE
Remove unneeded pip imports

### DIFF
--- a/aip/utils.py
+++ b/aip/utils.py
@@ -36,11 +36,7 @@ from aip.parser import parser
 from aip.logger import log
 from optparse import Option
 from pip._internal.commands.list import tabulate
-from pip._internal.utils.misc import (
-    dist_is_editable,
-    get_installed_distributions,
-    write_output,
-)
+from pip._internal.utils.misc import write_output
 
 
 board  = partial(


### PR DESCRIPTION
AIP  imported two internal utils from Pip: dist_is_editable and  get_installed_distributions. Neither import is used anywhere. However, the release of Pip 21.3 removes both of these, which caused an error when running aip, so removing the imports is needed to restore proper function.